### PR TITLE
Fix redo command 

### DIFF
--- a/src/CommandRunner.java
+++ b/src/CommandRunner.java
@@ -670,7 +670,7 @@ public class CommandRunner {
 
             try {
                 lastCommand = cmdToRun;
-                lastArgs = argsToRun;
+                lastArgs = (ArrayList<String>) argsToRun.clone();
 
                 String result = cmd.run(playerName, argsToRun);
                 if (result != null)


### PR DESCRIPTION
It wasn't working correctly because the preprocessing for some commands was consuming elements in the array (`array.remove(i)` vs `array.get(i)`). Now it clones the array to avoid elements disappearing.